### PR TITLE
Add secureboot pkcs11 signer

### DIFF
--- a/cmd/ukify.go
+++ b/cmd/ukify.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"log/slog"
+	"os"
 	"strings"
 )
 
@@ -15,6 +16,11 @@ var createUkify = &cobra.Command{
 	Short: "Create a uki file",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var parsedPhases []types.PhaseInfo
+
+		if viper.GetBool("debug") {
+			h := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})
+			slog.SetDefault(slog.New(h))
+		}
 
 		phases := viper.GetString("phases")
 		// Default to know systemd phases
@@ -25,10 +31,6 @@ var createUkify = &cobra.Command{
 			for _, phase := range strings.Split(phases, ":") {
 				parsedPhases = append(parsedPhases, types.PhaseInfo{Phase: constants.Phase(phase)})
 			}
-		}
-
-		if viper.GetBool("debug") {
-			slog.SetLogLoggerLevel(slog.LevelDebug)
 		}
 
 		builder := &uki.Builder{

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
 module github.com/kairos-io/go-ukify
 
-go 1.22.1
+go 1.24.2
 
 require (
+	github.com/ThalesGroup/crypto11 v1.4.1
 	github.com/foxboron/go-uefi v0.0.0-20241017190036-fab4fdf2f2f3
 	github.com/google/go-tpm v0.9.5
 	github.com/onsi/ginkgo/v2 v2.21.0
@@ -21,6 +22,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
+	github.com/miekg/pkcs11 v1.1.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
@@ -31,6 +33,7 @@ require (
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/thales-e-security/pool v0.0.2 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/crypto v0.32.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/ThalesGroup/crypto11 v1.4.1 h1:6YR6aVL8LI8akReXKTEgxf+k0+b8wlV8Ra7tZnCG9y4=
+github.com/ThalesGroup/crypto11 v1.4.1/go.mod h1:vggvBwlVrqePDrooq/B32dMXlfEsdsFY+6YlSD7VOy0=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -48,6 +50,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
+github.com/miekg/pkcs11 v1.1.1 h1:Ugu9pdy6vAYku5DEpVWVFPYnzV+bxB+iRdbuFSu7TvU=
+github.com/miekg/pkcs11 v1.1.1/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/onsi/ginkgo/v2 v2.19.0 h1:9Cnnf7UHo57Hy3k6/m5k3dRfGTMXGvxhHFvkDTCTpvA=
@@ -118,6 +122,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+github.com/thales-e-security/pool v0.0.2 h1:RAPs4q2EbWsTit6tpzuvTFlgFRJ3S8Evf5gtvVDbmPg=
+github.com/thales-e-security/pool v0.0.2/go.mod h1:qtpMm2+thHtqhLzTwgDBj/OuNnMpupY8mv0Phz0gjhU=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1 h1:A/5uWzF44DlIgdm/PQFwfMkW0JX+cIcQi/SwLAmZP5M=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=

--- a/pkg/pesign/pkcs11.go
+++ b/pkg/pesign/pkcs11.go
@@ -68,9 +68,10 @@ func loadPKCS11Signer(pkcs11uri string) (crypto.Signer, error) {
 		conf.SlotNumber = &slotID
 	}
 
-	// Check if the module file exists and log its permissions
+	// Check if the module file exists and return an error if not found
 	if stat, statErr := os.Stat(modulePath); statErr != nil {
 		slog.Error("PKCS#11 module file not found", "path", modulePath, "statErr", statErr)
+		return nil, fmt.Errorf("PKCS#11 module file not found at path '%s': %w", modulePath, statErr)
 	} else {
 		slog.Debug("PKCS#11 module file found", "path", modulePath, "mode", stat.Mode(), "size", stat.Size())
 	}

--- a/pkg/pesign/pkcs11.go
+++ b/pkg/pesign/pkcs11.go
@@ -3,8 +3,11 @@ package pesign
 import (
 	"crypto"
 	"errors"
+	"fmt"
 	"github.com/ThalesGroup/crypto11"
+	"log/slog"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -14,18 +17,41 @@ import (
 // pkcs11:module-path=<path>;pin-value=<pin>;token=<token-label>;slot-id=<slot-id>;id=<key-id>
 // or
 // pkcs11:module-path=<path>;pin-value=<pin>;object=<key-object-label>
+// Looks like the required arguments are:
+// - module-path: Path to the PKCS#11 module
+// - pin-value: PIN for the token.
+// TODO: We could also support passing the PIN via an environment variable for security, or dropping and asking for the PIN
+// TODO: We should check which parameters are required and optional and so on, but looking and the config seems like we are covered
 func loadPKCS11Signer(pkcs11uri string) (crypto.Signer, error) {
+	slog.Debug("PKCS#11 URI input", "uri", pkcs11uri)
 	uri, err := url.Parse(pkcs11uri)
 	if err != nil {
+		slog.Error("Failed to parse PKCS#11 URI", "error", err)
 		return nil, err
 	}
 
-	params := uri.Query()
+	slog.Debug("Parsed URI", "scheme", uri.Scheme, "opaque", uri.Opaque, "rawquery", uri.RawQuery)
 
-	modulePath := params.Get("module-path")
-	pin := params.Get("pin-value")
+	// Parse parameters from the opaque part (not query params)
+	params := make(map[string]string)
+	for _, param := range strings.Split(uri.Opaque, ";") {
+		if param == "" {
+			continue
+		}
+		kv := strings.SplitN(param, "=", 2)
+		if len(kv) == 2 {
+			params[kv[0]] = kv[1]
+		}
+	}
+	slog.Debug("Parsed params from opaque", "params", params)
+
+	modulePath := params["module-path"]
+	pin := params["pin-value"]
+
+	slog.Debug("Extracted module-path and pin-value", "module-path", modulePath, "pin-value", pin)
 
 	if modulePath == "" || pin == "" {
+		slog.Error("module-path and pin-value required in PKCS#11 URI", "module-path", modulePath, "pin-value", pin)
 		return nil, errors.New("module-path and pin-value required in PKCS#11 URI")
 	}
 
@@ -34,53 +60,77 @@ func loadPKCS11Signer(pkcs11uri string) (crypto.Signer, error) {
 		Pin:  pin,
 	}
 
-	tokenParams := strings.Split(uri.Opaque, ";")
-	for _, param := range tokenParams {
-		if strings.HasPrefix(param, "token=") {
-			conf.TokenLabel = strings.TrimPrefix(param, "token=")
-		} else if strings.HasPrefix(param, "slot-id=") {
-			slotID, err := strconv.Atoi(strings.TrimPrefix(param, "slot-id="))
-			if err != nil {
-				return nil, err
-			}
-			conf.SlotNumber = &slotID
+	if tokenLabel, ok := params["token"]; ok {
+		conf.TokenLabel = tokenLabel
+	}
+	if slotIDStr, ok := params["slot-id"]; ok {
+		slotID, err := strconv.Atoi(slotIDStr)
+		if err != nil {
+			return nil, err
 		}
+		conf.SlotNumber = &slotID
+	}
+
+	// Check if the module file exists and log its permissions
+	if stat, statErr := os.Stat(modulePath); statErr != nil {
+		slog.Error("PKCS#11 module file not found", "path", modulePath, "statErr", statErr)
+	} else {
+		slog.Debug("PKCS#11 module file found", "path", modulePath, "mode", stat.Mode(), "size", stat.Size())
 	}
 
 	ctx, err := crypto11.Configure(conf)
 	if err != nil {
+		slog.Error("crypto11.Configure failed", "error", err, "errorDetails", fmt.Sprintf("%+v", err), "conf.Path", conf.Path, "conf.Pin", conf.Pin, "conf.TokenLabel", conf.TokenLabel, "conf.SlotNumber", conf.SlotNumber)
 		return nil, err
 	}
 
 	var key crypto.Signer
-	for _, param := range tokenParams {
-		if strings.HasPrefix(param, "id=") {
-			idHex := strings.TrimPrefix(param, "id=")
-			keyID, err := url.PathUnescape(idHex)
-			if err != nil {
-				return nil, err
+	var idBytes []byte
+	if id, ok := params["id"]; ok {
+		// Try to decode as hex if it looks like hex
+		if len(id)%2 == 0 {
+			decoded := make([]byte, len(id)/2)
+			hexOk := true
+			for i := 0; i < len(id); i += 2 {
+				var b byte
+				_, err := fmt.Sscanf(id[i:i+2], "%02x", &b)
+				if err != nil {
+					hexOk = false
+					break
+				}
+				decoded[i/2] = b
 			}
-			key, err = ctx.FindKeyPair(nil, []byte(keyID))
-			if err != nil {
-				return nil, err
+			if hexOk {
+				idBytes = decoded
+				slog.Debug("Decoded id as hex", "id", id, "idBytes", idBytes)
+			} else {
+				idBytes = []byte(id)
+				slog.Debug("Failed to decode id as hex, using as ASCII bytes", "id", id, "idBytes", idBytes)
 			}
-			if key == nil {
-				return nil, errors.New("no key found with specified ID on PKCS#11 token")
-			}
+		} else {
+			idBytes = []byte(id)
+		}
+	}
+	if len(idBytes) > 0 {
+		slog.Debug("Tried FindKeyPair by id", "idBytes", idBytes, "err", err)
+		key, err = ctx.FindKeyPair(idBytes, nil)
+		if err != nil {
+			return nil, err
+		}
+		if key != nil {
 			return key, nil
 		}
-		if strings.HasPrefix(param, "object=") {
-			label := strings.TrimPrefix(param, "object=")
-			key, err = ctx.FindKeyPair([]byte(label), nil)
-			if err != nil {
-				return nil, err
-			}
-			if key == nil {
-				return nil, errors.New("no key found with specified object label on PKCS#11 token")
-			}
+	}
+	if label, ok := params["object"]; ok {
+		slog.Debug("Tried FindKeyPair by label", "label", label, "err", err)
+		key, err = ctx.FindKeyPair(nil, []byte(label))
+		if err != nil {
+			return nil, err
+		}
+		if key != nil {
 			return key, nil
 		}
 	}
 
-	return nil, errors.New("no valid key identifier (id= or object=) provided in PKCS#11 URI")
+	return nil, errors.New("no key found with specified ID or object label on PKCS#11 token")
 }

--- a/pkg/pesign/pkcs11.go
+++ b/pkg/pesign/pkcs11.go
@@ -48,7 +48,7 @@ func loadPKCS11Signer(pkcs11uri string) (crypto.Signer, error) {
 	modulePath := params["module-path"]
 	pin := params["pin-value"]
 
-	slog.Debug("Extracted module-path and pin-value", "module-path", modulePath, "pin-value", pin)
+	slog.Debug("Extracted module-path and pin-value", "module-path", modulePath, "pin-value", "***")
 
 	if modulePath == "" || pin == "" {
 		slog.Error("module-path and pin-value required in PKCS#11 URI", "module-path", modulePath, "pin-value", pin)
@@ -112,8 +112,8 @@ func loadPKCS11Signer(pkcs11uri string) (crypto.Signer, error) {
 		}
 	}
 	if len(idBytes) > 0 {
-		slog.Debug("Tried FindKeyPair by id", "idBytes", idBytes, "err", err)
 		key, err = ctx.FindKeyPair(idBytes, nil)
+		slog.Debug("Tried FindKeyPair by id", "idBytes", idBytes, "err", err)
 		if err != nil {
 			return nil, err
 		}
@@ -122,8 +122,8 @@ func loadPKCS11Signer(pkcs11uri string) (crypto.Signer, error) {
 		}
 	}
 	if label, ok := params["object"]; ok {
-		slog.Debug("Tried FindKeyPair by label", "label", label, "err", err)
 		key, err = ctx.FindKeyPair(nil, []byte(label))
+		slog.Debug("Tried FindKeyPair by label", "label", label, "err", err)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/pesign/pkcs11.go
+++ b/pkg/pesign/pkcs11.go
@@ -80,7 +80,7 @@ func loadPKCS11Signer(pkcs11uri string) (crypto.Signer, error) {
 
 	ctx, err := crypto11.Configure(conf)
 	if err != nil {
-		slog.Error("crypto11.Configure failed", "error", err, "errorDetails", fmt.Sprintf("%+v", err), "conf.Path", conf.Path, "conf.Pin", conf.Pin, "conf.TokenLabel", conf.TokenLabel, "conf.SlotNumber", conf.SlotNumber)
+		slog.Error("crypto11.Configure failed", "error", err, "errorDetails", fmt.Sprintf("%+v", err), "conf.Path", conf.Path, "conf.Pin", "***", "conf.TokenLabel", conf.TokenLabel, "conf.SlotNumber", conf.SlotNumber)
 		return nil, err
 	}
 

--- a/pkg/pesign/pkcs11.go
+++ b/pkg/pesign/pkcs11.go
@@ -89,16 +89,13 @@ func loadPKCS11Signer(pkcs11uri string) (crypto.Signer, error) {
 	if id, ok := params["id"]; ok {
 		// Try to decode as hex if it looks like hex
 		if len(id)%2 == 0 {
-			decoded := make([]byte, len(id)/2)
-			hexOk := true
-			for i := 0; i < len(id); i += 2 {
-				var b byte
-				_, err := fmt.Sscanf(id[i:i+2], "%02x", &b)
-				if err != nil {
-					hexOk = false
-					break
-				}
-				decoded[i/2] = b
+			decoded, err := hex.DecodeString(id)
+			if err == nil {
+				idBytes = decoded
+				slog.Debug("Decoded id as hex", "id", id, "idBytes", idBytes)
+			} else {
+				idBytes = []byte(id)
+				slog.Debug("Failed to decode id as hex, using as ASCII bytes", "id", id, "idBytes", idBytes)
 			}
 			if hexOk {
 				idBytes = decoded

--- a/pkg/pesign/pkcs11.go
+++ b/pkg/pesign/pkcs11.go
@@ -1,0 +1,86 @@
+package pesign
+
+import (
+	"crypto"
+	"errors"
+	"github.com/ThalesGroup/crypto11"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// loadPKCS11Signer loads a PKCS#11 signer from a URI.
+// The URI should be in the format:
+// pkcs11:module-path=<path>;pin-value=<pin>;token=<token-label>;slot-id=<slot-id>;id=<key-id>
+// or
+// pkcs11:module-path=<path>;pin-value=<pin>;object=<key-object-label>
+func loadPKCS11Signer(pkcs11uri string) (crypto.Signer, error) {
+	uri, err := url.Parse(pkcs11uri)
+	if err != nil {
+		return nil, err
+	}
+
+	params := uri.Query()
+
+	modulePath := params.Get("module-path")
+	pin := params.Get("pin-value")
+
+	if modulePath == "" || pin == "" {
+		return nil, errors.New("module-path and pin-value required in PKCS#11 URI")
+	}
+
+	conf := &crypto11.Config{
+		Path: modulePath,
+		Pin:  pin,
+	}
+
+	tokenParams := strings.Split(uri.Opaque, ";")
+	for _, param := range tokenParams {
+		if strings.HasPrefix(param, "token=") {
+			conf.TokenLabel = strings.TrimPrefix(param, "token=")
+		} else if strings.HasPrefix(param, "slot-id=") {
+			slotID, err := strconv.Atoi(strings.TrimPrefix(param, "slot-id="))
+			if err != nil {
+				return nil, err
+			}
+			conf.SlotNumber = &slotID
+		}
+	}
+
+	ctx, err := crypto11.Configure(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	var key crypto.Signer
+	for _, param := range tokenParams {
+		if strings.HasPrefix(param, "id=") {
+			idHex := strings.TrimPrefix(param, "id=")
+			keyID, err := url.PathUnescape(idHex)
+			if err != nil {
+				return nil, err
+			}
+			key, err = ctx.FindKeyPair(nil, []byte(keyID))
+			if err != nil {
+				return nil, err
+			}
+			if key == nil {
+				return nil, errors.New("no key found with specified ID on PKCS#11 token")
+			}
+			return key, nil
+		}
+		if strings.HasPrefix(param, "object=") {
+			label := strings.TrimPrefix(param, "object=")
+			key, err = ctx.FindKeyPair([]byte(label), nil)
+			if err != nil {
+				return nil, err
+			}
+			if key == nil {
+				return nil, errors.New("no key found with specified object label on PKCS#11 token")
+			}
+			return key, nil
+		}
+	}
+
+	return nil, errors.New("no valid key identifier (id= or object=) provided in PKCS#11 URI")
+}

--- a/pkg/uki/sbat.go
+++ b/pkg/uki/sbat.go
@@ -15,7 +15,7 @@ import (
 func GetSBAT(path string) ([]byte, error) {
 	pefile, err := pe.Open(path)
 	if err != nil {
-		slog.Info("ERROROROROROR")
+		slog.Error("failed to open PE file", "path", path, "error", err)
 		return nil, err
 	}
 

--- a/pkg/uki/sbat.go
+++ b/pkg/uki/sbat.go
@@ -8,12 +8,14 @@ import (
 	"debug/pe"
 	"errors"
 	"github.com/kairos-io/go-ukify/pkg/constants"
+	"log/slog"
 )
 
 // GetSBAT returns the SBAT section from the PE file.
 func GetSBAT(path string) ([]byte, error) {
 	pefile, err := pe.Open(path)
 	if err != nil {
+		slog.Info("ERROROROROROR")
 		return nil, err
 	}
 


### PR DESCRIPTION
Part of https://github.com/kairos-io/kairos/issues/3222

Was able to sign a file by using a hardware key with the following command:

```
$ go run main.go create --sb-cert nitrokey.crt.pem -i initramfs -k vmlinuz -b systemd-bootaa64.efi -s linuxaa64.efi.stub --sb-key "pkcs11:module-path=/usr/lib64/pkcs11/opensc-pkcs11.so;slot-id=1;id=01;pin-value=123456" 
```

```
$ go run main.go create --debug --sb-cert nitrokey.crt.pem -i initramfs -k vmlinuz -b systemd-bootaa64.efi -s linuxaa64.efi.stub --sb-key "pkcs11:module-path=/usr/lib64/pkcs11/opensc-pkcs11.so;slot-id=1;id=01;pin-value=123456"
time=2025-06-26T19:14:46.659+02:00 level=DEBUG msg="PKCS#11 URI input" uri="pkcs11:module-path=/usr/lib64/pkcs11/opensc-pkcs11.so;slot-id=1;id=01;pin-value=123456"
time=2025-06-26T19:14:46.659+02:00 level=DEBUG msg="Parsed URI" scheme=pkcs11 opaque="module-path=/usr/lib64/pkcs11/opensc-pkcs11.so;slot-id=1;id=01;pin-value=123456" rawquery=""
time=2025-06-26T19:14:46.659+02:00 level=DEBUG msg="Parsed params from opaque" params="map[id:01 module-path:/usr/lib64/pkcs11/opensc-pkcs11.so pin-value:123456 slot-id:1]"
time=2025-06-26T19:14:46.659+02:00 level=DEBUG msg="Extracted module-path and pin-value" module-path=/usr/lib64/pkcs11/opensc-pkcs11.so pin-value=123456
time=2025-06-26T19:14:46.659+02:00 level=DEBUG msg="PKCS#11 module file found" path=/usr/lib64/pkcs11/opensc-pkcs11.so mode=-rwxr-xr-x size=283024
time=2025-06-26T19:14:46.713+02:00 level=DEBUG msg="Decoded id as hex" id=01 idBytes="\x01"
time=2025-06-26T19:14:46.713+02:00 level=DEBUG msg="Tried FindKeyPair by id" idBytes="\x01" err=<nil>
time=2025-06-26T19:14:46.713+02:00 level=INFO msg="Signing systemd-boot" path=systemd-bootaa64.efi
time=2025-06-26T19:14:46.713+02:00 level=DEBUG msg="Signing file" input=systemd-bootaa64.efi output=sdboot.signed.efi
time=2025-06-26T19:14:47.619+02:00 level=INFO msg="Signed systemd-boot" path=sdboot.signed.efi
time=2025-06-26T19:14:47.619+02:00 level=INFO msg="Generating UKI sections"
time=2025-06-26T19:14:47.619+02:00 level=DEBUG msg="Generating a new os-release"
time=2025-06-26T19:14:47.619+02:00 level=DEBUG msg="Using cmdline" cmdline=""
time=2025-06-26T19:14:47.619+02:00 level=DEBUG msg="Using initrd" path=initramfs
time=2025-06-26T19:14:47.619+02:00 level=DEBUG msg="Using generic bundled splash"
time=2025-06-26T19:14:47.621+02:00 level=INFO msg="We could not infer kernel version" path=vmlinuz
time=2025-06-26T19:14:47.621+02:00 level=DEBUG msg="Getting SBAT" path=linuxaa64.efi.stub
time=2025-06-26T19:14:47.621+02:00 level=DEBUG msg="Generated SBAT" sbat="sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md\nsystemd-stub,1,The systemd Developers,systemd,255,https://systemd.io/\nsystemd-stub.fedora-asahi-remix,1,Fedora Linux Asahi Remix,systemd,255,https://bugzilla.redhat.com/\n\x00" path=linuxaa64.efi.stub
time=2025-06-26T19:14:47.621+02:00 level=DEBUG msg="Getting kernel"
time=2025-06-26T19:14:47.621+02:00 level=INFO msg="Generating PCR measurements"
time=2025-06-26T19:14:47.621+02:00 level=DEBUG msg="Using PCR slot" number=11
time=2025-06-26T19:14:47.621+02:00 level=DEBUG msg="Generating PCR data" sections="map[.cmdline:/tmp/ukify126966499/cmdline .initrd:initramfs .linux:vmlinuz .osrel:/tmp/ukify126966499/os-release .sbat:/tmp/ukify126966499/sbat .splash:/tmp/ukify126966499/splash.bmp]"
time=2025-06-26T19:14:47.621+02:00 level=INFO msg="Not signing data, just outputting it to stdout"
time=2025-06-26T19:14:47.621+02:00 level=INFO msg="legend: <PHASE:PCR:ALGORITHM=HASH>"
time=2025-06-26T19:14:47.622+02:00 level=DEBUG msg="Measuring section" section=.linux alg=SHA-1
time=2025-06-26T19:14:47.683+02:00 level=DEBUG msg="Measuring section" section=.osrel alg=SHA-1
time=2025-06-26T19:14:47.683+02:00 level=DEBUG msg="Measuring section" section=.cmdline alg=SHA-1
time=2025-06-26T19:14:47.683+02:00 level=DEBUG msg="Measuring section" section=.initrd alg=SHA-1
time=2025-06-26T19:14:47.733+02:00 level=DEBUG msg="Measuring section" section=.splash alg=SHA-1
time=2025-06-26T19:14:47.735+02:00 level=DEBUG msg="Measuring section" section=.sbat alg=SHA-1
time=2025-06-26T19:14:47.735+02:00 level=DEBUG msg="Doing phase" phase=enter-initrd alg=SHA-1
time=2025-06-26T19:14:47.735+02:00 level=DEBUG msg="Expected Hash calculated" hash=a6d599cd8629194aaa79af85ff7c2a8b7b5987c9 alg=SHA-1 phase=enter-initrd
time=2025-06-26T19:14:47.735+02:00 level=INFO msg="enter-initrd:11:SHA-1=a6d599cd8629194aaa79af85ff7c2a8b7b5987c9"
time=2025-06-26T19:14:47.735+02:00 level=DEBUG msg="Doing phase" phase=leave-initrd alg=SHA-1
time=2025-06-26T19:14:47.735+02:00 level=DEBUG msg="Expected Hash calculated" hash=c5db7c605b9653119b7fec2a30416f0112ae0f77 alg=SHA-1 phase=leave-initrd
time=2025-06-26T19:14:47.735+02:00 level=INFO msg="leave-initrd:11:SHA-1=c5db7c605b9653119b7fec2a30416f0112ae0f77"
time=2025-06-26T19:14:47.735+02:00 level=DEBUG msg="Doing phase" phase=sysinit alg=SHA-1
time=2025-06-26T19:14:47.735+02:00 level=DEBUG msg="Expected Hash calculated" hash=b3631c9bc11961e93b71938f828d6e39d0461230 alg=SHA-1 phase=sysinit
time=2025-06-26T19:14:47.735+02:00 level=INFO msg="sysinit:11:SHA-1=b3631c9bc11961e93b71938f828d6e39d0461230"
time=2025-06-26T19:14:47.735+02:00 level=DEBUG msg="Doing phase" phase=ready alg=SHA-1
time=2025-06-26T19:14:47.735+02:00 level=DEBUG msg="Expected Hash calculated" hash=9ed66b962425c00b097fcc5e95fc8c7245055121 alg=SHA-1 phase=ready
time=2025-06-26T19:14:47.735+02:00 level=INFO msg="ready:11:SHA-1=9ed66b962425c00b097fcc5e95fc8c7245055121"
time=2025-06-26T19:14:47.735+02:00 level=DEBUG msg="Measuring section" section=.linux alg=SHA-256
time=2025-06-26T19:14:47.763+02:00 level=DEBUG msg="Measuring section" section=.osrel alg=SHA-256
time=2025-06-26T19:14:47.763+02:00 level=DEBUG msg="Measuring section" section=.cmdline alg=SHA-256
time=2025-06-26T19:14:47.763+02:00 level=DEBUG msg="Measuring section" section=.initrd alg=SHA-256
time=2025-06-26T19:14:47.784+02:00 level=DEBUG msg="Measuring section" section=.splash alg=SHA-256
time=2025-06-26T19:14:47.785+02:00 level=DEBUG msg="Measuring section" section=.sbat alg=SHA-256
time=2025-06-26T19:14:47.785+02:00 level=DEBUG msg="Doing phase" phase=enter-initrd alg=SHA-256
time=2025-06-26T19:14:47.785+02:00 level=DEBUG msg="Expected Hash calculated" hash=8f40296ce2908b9e32bfad15995df91c74de7056dc0d5102c888085050e1f2cc alg=SHA-256 phase=enter-initrd
time=2025-06-26T19:14:47.785+02:00 level=INFO msg="enter-initrd:11:SHA-256=8f40296ce2908b9e32bfad15995df91c74de7056dc0d5102c888085050e1f2cc"
time=2025-06-26T19:14:47.785+02:00 level=DEBUG msg="Doing phase" phase=leave-initrd alg=SHA-256
time=2025-06-26T19:14:47.785+02:00 level=DEBUG msg="Expected Hash calculated" hash=eddc8b21a16faa079fdc831ba09cdeed6efea261fddbee9200720587b65ea896 alg=SHA-256 phase=leave-initrd
time=2025-06-26T19:14:47.785+02:00 level=INFO msg="leave-initrd:11:SHA-256=eddc8b21a16faa079fdc831ba09cdeed6efea261fddbee9200720587b65ea896"
time=2025-06-26T19:14:47.785+02:00 level=DEBUG msg="Doing phase" phase=sysinit alg=SHA-256
time=2025-06-26T19:14:47.785+02:00 level=DEBUG msg="Expected Hash calculated" hash=0df03772ce9de725d45b994c57a56b5de7b4b6885a962bc2ed5a2687573548ef alg=SHA-256 phase=sysinit
time=2025-06-26T19:14:47.785+02:00 level=INFO msg="sysinit:11:SHA-256=0df03772ce9de725d45b994c57a56b5de7b4b6885a962bc2ed5a2687573548ef"
time=2025-06-26T19:14:47.785+02:00 level=DEBUG msg="Doing phase" phase=ready alg=SHA-256
time=2025-06-26T19:14:47.785+02:00 level=DEBUG msg="Expected Hash calculated" hash=7583caf6a884311be1d9281c35fe4e8fbe89a9dc3cbfe675e7dfd1bbb06fefe8 alg=SHA-256 phase=ready
time=2025-06-26T19:14:47.785+02:00 level=INFO msg="ready:11:SHA-256=7583caf6a884311be1d9281c35fe4e8fbe89a9dc3cbfe675e7dfd1bbb06fefe8"
time=2025-06-26T19:14:47.785+02:00 level=DEBUG msg="Measuring section" section=.linux alg=SHA-384
time=2025-06-26T19:14:47.807+02:00 level=DEBUG msg="Measuring section" section=.osrel alg=SHA-384
time=2025-06-26T19:14:47.807+02:00 level=DEBUG msg="Measuring section" section=.cmdline alg=SHA-384
time=2025-06-26T19:14:47.807+02:00 level=DEBUG msg="Measuring section" section=.initrd alg=SHA-384
time=2025-06-26T19:14:47.835+02:00 level=DEBUG msg="Measuring section" section=.splash alg=SHA-384
time=2025-06-26T19:14:47.836+02:00 level=DEBUG msg="Measuring section" section=.sbat alg=SHA-384
time=2025-06-26T19:14:47.836+02:00 level=DEBUG msg="Doing phase" phase=enter-initrd alg=SHA-384
time=2025-06-26T19:14:47.836+02:00 level=DEBUG msg="Expected Hash calculated" hash=826e5ea400be2ea5c365382e12f434f836508a47ee559ea47248751867faa4d24c5cc861a6856e9e453e94e80b4f360a alg=SHA-384 phase=enter-initrd
time=2025-06-26T19:14:47.836+02:00 level=INFO msg="enter-initrd:11:SHA-384=826e5ea400be2ea5c365382e12f434f836508a47ee559ea47248751867faa4d24c5cc861a6856e9e453e94e80b4f360a"
time=2025-06-26T19:14:47.836+02:00 level=DEBUG msg="Doing phase" phase=leave-initrd alg=SHA-384
time=2025-06-26T19:14:47.836+02:00 level=DEBUG msg="Expected Hash calculated" hash=b5aa18003dab75c1b624d4ead9f9119fcd25a1997a436292f2b02aca0123613e208946b88bacc61b5e637ec48b6beafc alg=SHA-384 phase=leave-initrd
time=2025-06-26T19:14:47.836+02:00 level=INFO msg="leave-initrd:11:SHA-384=b5aa18003dab75c1b624d4ead9f9119fcd25a1997a436292f2b02aca0123613e208946b88bacc61b5e637ec48b6beafc"
time=2025-06-26T19:14:47.836+02:00 level=DEBUG msg="Doing phase" phase=sysinit alg=SHA-384
time=2025-06-26T19:14:47.836+02:00 level=DEBUG msg="Expected Hash calculated" hash=dfbd1876c6fe4e08ff7f2fb5876bb209d8d91f5df4079b08b44ab0ea7fcc8e97f67198ea32b9ec0d637056b99b789845 alg=SHA-384 phase=sysinit
time=2025-06-26T19:14:47.836+02:00 level=INFO msg="sysinit:11:SHA-384=dfbd1876c6fe4e08ff7f2fb5876bb209d8d91f5df4079b08b44ab0ea7fcc8e97f67198ea32b9ec0d637056b99b789845"
time=2025-06-26T19:14:47.836+02:00 level=DEBUG msg="Doing phase" phase=ready alg=SHA-384
time=2025-06-26T19:14:47.836+02:00 level=DEBUG msg="Expected Hash calculated" hash=a471c047ee1a9e01557779183473bc6fa11949cd29cac9d88919fd295c329bdbb0c4909cdb8c6494d2bc173279f3cc3b alg=SHA-384 phase=ready
time=2025-06-26T19:14:47.836+02:00 level=INFO msg="ready:11:SHA-384=a471c047ee1a9e01557779183473bc6fa11949cd29cac9d88919fd295c329bdbb0c4909cdb8c6494d2bc173279f3cc3b"
time=2025-06-26T19:14:47.836+02:00 level=DEBUG msg="Measuring section" section=.linux alg=SHA-512
time=2025-06-26T19:14:47.857+02:00 level=DEBUG msg="Measuring section" section=.osrel alg=SHA-512
time=2025-06-26T19:14:47.857+02:00 level=DEBUG msg="Measuring section" section=.cmdline alg=SHA-512
time=2025-06-26T19:14:47.857+02:00 level=DEBUG msg="Measuring section" section=.initrd alg=SHA-512
time=2025-06-26T19:14:47.915+02:00 level=DEBUG msg="Measuring section" section=.splash alg=SHA-512
time=2025-06-26T19:14:47.917+02:00 level=DEBUG msg="Measuring section" section=.sbat alg=SHA-512
time=2025-06-26T19:14:47.917+02:00 level=DEBUG msg="Doing phase" phase=enter-initrd alg=SHA-512
time=2025-06-26T19:14:47.917+02:00 level=DEBUG msg="Expected Hash calculated" hash=45b14655bffa62eb75f66253336459e86d8a08de0af0e31b3137a791155fc4e49c9b61f8feaa2446e5714034f83a391380fee8739de1bd41dc177e669353fd7e alg=SHA-512 phase=enter-initrd
time=2025-06-26T19:14:47.917+02:00 level=INFO msg="enter-initrd:11:SHA-512=45b14655bffa62eb75f66253336459e86d8a08de0af0e31b3137a791155fc4e49c9b61f8feaa2446e5714034f83a391380fee8739de1bd41dc177e669353fd7e"
time=2025-06-26T19:14:47.917+02:00 level=DEBUG msg="Doing phase" phase=leave-initrd alg=SHA-512
time=2025-06-26T19:14:47.917+02:00 level=DEBUG msg="Expected Hash calculated" hash=4e48bc5c021c6f8a74245916c71d4c933621a191aeab8929bf7282c32fd3a4b00ba6f1fbef72d6799abdde06a003b247373890f77c92c06da1fc0bff327ab7a6 alg=SHA-512 phase=leave-initrd
time=2025-06-26T19:14:47.917+02:00 level=INFO msg="leave-initrd:11:SHA-512=4e48bc5c021c6f8a74245916c71d4c933621a191aeab8929bf7282c32fd3a4b00ba6f1fbef72d6799abdde06a003b247373890f77c92c06da1fc0bff327ab7a6"
time=2025-06-26T19:14:47.917+02:00 level=DEBUG msg="Doing phase" phase=sysinit alg=SHA-512
time=2025-06-26T19:14:47.917+02:00 level=DEBUG msg="Expected Hash calculated" hash=d1a9e5c0a2b897d870b2238bd036fb2a5ac1b0728efd8f4e463a2f3a5121527599e4aa5b77dee1042d26e3a8c984521b630f0835e44ee4fa4fa9484d01ce7b76 alg=SHA-512 phase=sysinit
time=2025-06-26T19:14:47.917+02:00 level=INFO msg="sysinit:11:SHA-512=d1a9e5c0a2b897d870b2238bd036fb2a5ac1b0728efd8f4e463a2f3a5121527599e4aa5b77dee1042d26e3a8c984521b630f0835e44ee4fa4fa9484d01ce7b76"
time=2025-06-26T19:14:47.917+02:00 level=DEBUG msg="Doing phase" phase=ready alg=SHA-512
time=2025-06-26T19:14:47.917+02:00 level=DEBUG msg="Expected Hash calculated" hash=e38578e9fa833a99d79a7501c510aba1b2b66a12e9b7369a36907a6f16f4ec0da5209c62725c495da42073a3bea63b45a920f46db4d5fe8918f5672a19f18860 alg=SHA-512 phase=ready
time=2025-06-26T19:14:47.917+02:00 level=INFO msg="ready:11:SHA-512=e38578e9fa833a99d79a7501c510aba1b2b66a12e9b7369a36907a6f16f4ec0da5209c62725c495da42073a3bea63b45a920f46db4d5fe8918f5672a19f18860"
time=2025-06-26T19:14:47.917+02:00 level=INFO msg="Generated UKI sections"
time=2025-06-26T19:14:47.917+02:00 level=INFO msg="Assembling UKI"
time=2025-06-26T19:14:47.917+02:00 level=DEBUG msg=Assembling args="[--add-section .osrel=/tmp/ukify126966499/os-release --change-section-vma .osrel=0x1d1fa4200 --add-section .cmdline=/tmp/ukify126966499/cmdline --change-section-vma .cmdline=0x1d1fa4400 --add-section .initrd=initramfs --change-section-vma .initrd=0x1d1fa4400 --add-section .splash=/tmp/ukify126966499/splash.bmp --change-section-vma .splash=0x1d37e0000 --add-section .linux=vmlinuz --change-section-vma .linux=0x1d390c200 --set-section-flags .linux=code,readonly linuxaa64.efi.stub /tmp/ukify126966499/unsigned.uki]"
time=2025-06-26T19:14:47.977+02:00 level=INFO msg="Assembled UKI"
time=2025-06-26T19:14:47.977+02:00 level=INFO msg="Signing UKI"
time=2025-06-26T19:14:47.977+02:00 level=DEBUG msg="Signing file" input=/tmp/ukify126966499/unsigned.uki output=uki.signed.efi
time=2025-06-26T19:14:49.382+02:00 level=INFO msg="Signed UKI at uki.signed.efi"
```

```
$ sbverify --list sdboot.signed.efi 
signature 1
image signature issuers:
 - /CN=Mac Key
image signature certificates:
 - subject: /CN=Mac Key
   issuer:  /CN=Mac Key

# itxaka @ fedora in ~/projects/go-ukify on git:pkcs11-signer x [19:15:26] 
$ sbverify --list uki.signed.efi 
signature 1
image signature issuers:
 - /CN=Mac Key
image signature certificates:
 - subject: /CN=Mac Key
   issuer:  /CN=Mac Key
```

